### PR TITLE
Allow uploading of exports/1.0/IHO_V10, and exports/2.0/IHO_V12

### DIFF
--- a/S-101_Test_DataSets/exports/1.0/IHO_V10/S100_ROOT/CATALOG.XML
+++ b/S-101_Test_DataSets/exports/1.0/IHO_V10/S100_ROOT/CATALOG.XML
@@ -1009,7 +1009,7 @@
             </S100XC:producingAgency>
             <S100XC:producerCode>4</S100XC:producerCode>
             <S100XC:encodingFormat>ISO/IEC 8211</S100XC:encodingFormat>
-            <S100XC:defaultLocale xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="S100XC:S100_PT_Locale_PropertyType" gco:isoType="ENG"/>
+            <S100XC:defaultLocale xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="lan:PT_Locale_PropertyType" gco:isoType="ENG"/>
             <S100XC:metadataPointOfContact>
                 <cit:CI_Responsibility>
                     <cit:role>
@@ -1062,7 +1062,7 @@
             </S100XC:producingAgency>
             <S100XC:producerCode>4</S100XC:producerCode>
             <S100XC:encodingFormat>ISO/IEC 8211</S100XC:encodingFormat>
-            <S100XC:defaultLocale xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="S100XC:S100_PT_Locale_PropertyType" gco:isoType="ENG"/>
+            <S100XC:defaultLocale xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="lan:PT_Locale_PropertyType" gco:isoType="ENG"/>
             <S100XC:metadataPointOfContact>
                 <cit:CI_Responsibility>
                     <cit:role>
@@ -1115,7 +1115,7 @@
             </S100XC:producingAgency>
             <S100XC:producerCode>4</S100XC:producerCode>
             <S100XC:encodingFormat>ISO/IEC 8211</S100XC:encodingFormat>
-            <S100XC:defaultLocale xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="S100XC:S100_PT_Locale_PropertyType" gco:isoType="ENG"/>
+            <S100XC:defaultLocale xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="lan:PT_Locale_PropertyType" gco:isoType="ENG"/>
             <S100XC:metadataPointOfContact>
                 <cit:CI_Responsibility>
                     <cit:role>
@@ -1168,7 +1168,7 @@
             </S100XC:producingAgency>
             <S100XC:producerCode>4</S100XC:producerCode>
             <S100XC:encodingFormat>ISO/IEC 8211</S100XC:encodingFormat>
-            <S100XC:defaultLocale xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="S100XC:S100_PT_Locale_PropertyType" gco:isoType="ENG"/>
+            <S100XC:defaultLocale xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="lan:PT_Locale_PropertyType" gco:isoType="ENG"/>
             <S100XC:metadataPointOfContact>
                 <cit:CI_Responsibility>
                     <cit:role>
@@ -1221,7 +1221,7 @@
             </S100XC:producingAgency>
             <S100XC:producerCode>4</S100XC:producerCode>
             <S100XC:encodingFormat>ISO/IEC 8211</S100XC:encodingFormat>
-            <S100XC:defaultLocale xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="S100XC:S100_PT_Locale_PropertyType" gco:isoType="ENG"/>
+            <S100XC:defaultLocale xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="lan:PT_Locale_PropertyType" gco:isoType="ENG"/>
             <S100XC:metadataPointOfContact>
                 <cit:CI_Responsibility>
                     <cit:role>
@@ -1274,7 +1274,7 @@
             </S100XC:producingAgency>
             <S100XC:producerCode>4</S100XC:producerCode>
             <S100XC:encodingFormat>ISO/IEC 8211</S100XC:encodingFormat>
-            <S100XC:defaultLocale xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="S100XC:S100_PT_Locale_PropertyType" gco:isoType="ENG"/>
+            <S100XC:defaultLocale xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="lan:PT_Locale_PropertyType" gco:isoType="ENG"/>
             <S100XC:metadataPointOfContact>
                 <cit:CI_Responsibility>
                     <cit:role>

--- a/S-101_Test_DataSets/exports/1.0/IHO_V10/S100_ROOT/CATALOG.XML
+++ b/S-101_Test_DataSets/exports/1.0/IHO_V10/S100_ROOT/CATALOG.XML
@@ -83,7 +83,7 @@
                 <S100XC:version>1.1.0</S100XC:version>
                 <S100XC:date>2018-12-01</S100XC:date>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>101</S100XC:number>
+                <S100XC:number>214</S100XC:number>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
                 <cit:CI_Responsibility>
@@ -187,7 +187,7 @@
                 <S100XC:version>1.1.0</S100XC:version>
                 <S100XC:date>2018-12-01</S100XC:date>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>101</S100XC:number>
+                <S100XC:number>214</S100XC:number>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
                 <cit:CI_Responsibility>
@@ -291,7 +291,7 @@
                 <S100XC:version>1.1.0</S100XC:version>
                 <S100XC:date>2018-12-01</S100XC:date>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>101</S100XC:number>
+                <S100XC:number>214</S100XC:number>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
                 <cit:CI_Responsibility>
@@ -395,7 +395,7 @@
                 <S100XC:version>1.1.0</S100XC:version>
                 <S100XC:date>2018-12-01</S100XC:date>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>101</S100XC:number>
+                <S100XC:number>214</S100XC:number>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
                 <cit:CI_Responsibility>
@@ -499,7 +499,7 @@
                 <S100XC:version>1.1.0</S100XC:version>
                 <S100XC:date>2018-12-01</S100XC:date>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>101</S100XC:number>
+                <S100XC:number>214</S100XC:number>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
                 <cit:CI_Responsibility>
@@ -603,7 +603,7 @@
                 <S100XC:version>1.1.0</S100XC:version>
                 <S100XC:date>2018-12-01</S100XC:date>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>101</S100XC:number>
+                <S100XC:number>214</S100XC:number>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
                 <cit:CI_Responsibility>
@@ -707,7 +707,7 @@
                 <S100XC:version>1.1.0</S100XC:version>
                 <S100XC:date>2018-12-01</S100XC:date>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>101</S100XC:number>
+                <S100XC:number>214</S100XC:number>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
                 <cit:CI_Responsibility>
@@ -811,7 +811,7 @@
                 <S100XC:version>1.1.0</S100XC:version>
                 <S100XC:date>2018-12-01</S100XC:date>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>101</S100XC:number>
+                <S100XC:number>214</S100XC:number>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
                 <cit:CI_Responsibility>
@@ -915,7 +915,7 @@
                 <S100XC:version>1.1.0</S100XC:version>
                 <S100XC:date>2018-12-01</S100XC:date>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>101</S100XC:number>
+                <S100XC:number>214</S100XC:number>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
                 <cit:CI_Responsibility>
@@ -991,7 +991,7 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>101</S100XC:number>
+                <S100XC:number>214</S100XC:number>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
                 <cit:CI_Responsibility>
@@ -1044,7 +1044,7 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>101</S100XC:number>
+                <S100XC:number>214</S100XC:number>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
                 <cit:CI_Responsibility>
@@ -1097,7 +1097,7 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>101</S100XC:number>
+                <S100XC:number>214</S100XC:number>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
                 <cit:CI_Responsibility>
@@ -1150,7 +1150,7 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>101</S100XC:number>
+                <S100XC:number>214</S100XC:number>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
                 <cit:CI_Responsibility>
@@ -1203,7 +1203,7 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>101</S100XC:number>
+                <S100XC:number>214</S100XC:number>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
                 <cit:CI_Responsibility>
@@ -1256,7 +1256,7 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>101</S100XC:number>
+                <S100XC:number>214</S100XC:number>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
                 <cit:CI_Responsibility>

--- a/S-101_Test_DataSets/exports/1.0/IHO_V10/S100_ROOT/CATALOG.XML
+++ b/S-101_Test_DataSets/exports/1.0/IHO_V10/S100_ROOT/CATALOG.XML
@@ -80,7 +80,7 @@
             </S100XC:boundingBox>
             <S100XC:productSpecification>
                 <S100XC:name>S-101</S100XC:name>
-                <S100XC:version>010000</S100XC:version>
+                <S100XC:version>1.1.0</S100XC:version>
                 <S100XC:date>2018-12-01</S100XC:date>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
                 <S100XC:number>101</S100XC:number>
@@ -184,7 +184,7 @@
             </S100XC:boundingBox>
             <S100XC:productSpecification>
                 <S100XC:name>S-101</S100XC:name>
-                <S100XC:version>010000</S100XC:version>
+                <S100XC:version>1.1.0</S100XC:version>
                 <S100XC:date>2018-12-01</S100XC:date>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
                 <S100XC:number>101</S100XC:number>
@@ -288,7 +288,7 @@
             </S100XC:boundingBox>
             <S100XC:productSpecification>
                 <S100XC:name>S-101</S100XC:name>
-                <S100XC:version>010000</S100XC:version>
+                <S100XC:version>1.1.0</S100XC:version>
                 <S100XC:date>2018-12-01</S100XC:date>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
                 <S100XC:number>101</S100XC:number>
@@ -392,7 +392,7 @@
             </S100XC:boundingBox>
             <S100XC:productSpecification>
                 <S100XC:name>S-101</S100XC:name>
-                <S100XC:version>010000</S100XC:version>
+                <S100XC:version>1.1.0</S100XC:version>
                 <S100XC:date>2018-12-01</S100XC:date>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
                 <S100XC:number>101</S100XC:number>
@@ -496,7 +496,7 @@
             </S100XC:boundingBox>
             <S100XC:productSpecification>
                 <S100XC:name>S-101</S100XC:name>
-                <S100XC:version>010000</S100XC:version>
+                <S100XC:version>1.1.0</S100XC:version>
                 <S100XC:date>2018-12-01</S100XC:date>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
                 <S100XC:number>101</S100XC:number>
@@ -600,7 +600,7 @@
             </S100XC:boundingBox>
             <S100XC:productSpecification>
                 <S100XC:name>S-101</S100XC:name>
-                <S100XC:version>010000</S100XC:version>
+                <S100XC:version>1.1.0</S100XC:version>
                 <S100XC:date>2018-12-01</S100XC:date>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
                 <S100XC:number>101</S100XC:number>
@@ -704,7 +704,7 @@
             </S100XC:boundingBox>
             <S100XC:productSpecification>
                 <S100XC:name>S-101</S100XC:name>
-                <S100XC:version>010000</S100XC:version>
+                <S100XC:version>1.1.0</S100XC:version>
                 <S100XC:date>2018-12-01</S100XC:date>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
                 <S100XC:number>101</S100XC:number>
@@ -808,7 +808,7 @@
             </S100XC:boundingBox>
             <S100XC:productSpecification>
                 <S100XC:name>S-101</S100XC:name>
-                <S100XC:version>010000</S100XC:version>
+                <S100XC:version>1.1.0</S100XC:version>
                 <S100XC:date>2018-12-01</S100XC:date>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
                 <S100XC:number>101</S100XC:number>
@@ -912,7 +912,7 @@
             </S100XC:boundingBox>
             <S100XC:productSpecification>
                 <S100XC:name>S-101</S100XC:name>
-                <S100XC:version>010000</S100XC:version>
+                <S100XC:version>1.1.0</S100XC:version>
                 <S100XC:date>2018-12-01</S100XC:date>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
                 <S100XC:number>101</S100XC:number>
@@ -991,7 +991,7 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>1</S100XC:number>
+                <S100XC:number>101</S100XC:number>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
                 <cit:CI_Responsibility>
@@ -1044,7 +1044,7 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>1</S100XC:number>
+                <S100XC:number>101</S100XC:number>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
                 <cit:CI_Responsibility>
@@ -1097,7 +1097,7 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>1</S100XC:number>
+                <S100XC:number>101</S100XC:number>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
                 <cit:CI_Responsibility>
@@ -1150,7 +1150,7 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>1</S100XC:number>
+                <S100XC:number>101</S100XC:number>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
                 <cit:CI_Responsibility>
@@ -1203,7 +1203,7 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>1</S100XC:number>
+                <S100XC:number>101</S100XC:number>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
                 <cit:CI_Responsibility>
@@ -1256,7 +1256,7 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>1</S100XC:number>
+                <S100XC:number>101</S100XC:number>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
                 <cit:CI_Responsibility>

--- a/S-101_Test_DataSets/exports/2.0/IHO_V12/S100_ROOT/CATALOG.XML
+++ b/S-101_Test_DataSets/exports/2.0/IHO_V12/S100_ROOT/CATALOG.XML
@@ -54,7 +54,7 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>101</S100XC:number>
+                <S100XC:number>214</S100XC:number>
 		<S100XC:version>1.1.0</S100XC:version>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
@@ -91,7 +91,7 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>101</S100XC:number>
+                <S100XC:number>214</S100XC:number>
                 <S100XC:version>1.1.0</S100XC:version>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
@@ -128,7 +128,7 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>101</S100XC:number>
+                <S100XC:number>214</S100XC:number>
 		<S100XC:version>1.1.0</S100XC:version>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
@@ -165,7 +165,7 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>101</S100XC:number>
+                <S100XC:number>214</S100XC:number>
 		<S100XC:version>1.1.0</S100XC:version>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
@@ -202,7 +202,7 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>101</S100XC:number>
+                <S100XC:number>214</S100XC:number>
 		<S100XC:version>1.1.0</S100XC:version>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
@@ -239,7 +239,7 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>101</S100XC:number>
+                <S100XC:number>214</S100XC:number>
 		<S100XC:version>1.1.0</S100XC:version>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
@@ -276,7 +276,7 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>101</S100XC:number>
+                <S100XC:number>214</S100XC:number>
 		<S100XC:version>1.1.0</S100XC:version>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
@@ -313,7 +313,7 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>101</S100XC:number>
+                <S100XC:number>214</S100XC:number>
 		<S100XC:version>1.1.0</S100XC:version>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
@@ -350,7 +350,7 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>101</S100XC:number>
+                <S100XC:number>214</S100XC:number>
 		<S100XC:version>1.1.0</S100XC:version>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
@@ -387,7 +387,7 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>101</S100XC:number>
+                <S100XC:number>214</S100XC:number>
 		<S100XC:version>1.1.0</S100XC:version>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
@@ -424,7 +424,7 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>101</S100XC:number>
+                <S100XC:number>214</S100XC:number>
 		<S100XC:version>1.1.0</S100XC:version>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
@@ -461,7 +461,7 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>101</S100XC:number>
+                <S100XC:number>214</S100XC:number>
 		<S100XC:version>1.1.0</S100XC:version>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
@@ -498,7 +498,7 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>101</S100XC:number>
+                <S100XC:number>214</S100XC:number>
 		<S100XC:version>1.1.0</S100XC:version>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
@@ -535,7 +535,7 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>101</S100XC:number>
+                <S100XC:number>214</S100XC:number>
 		<S100XC:version>1.1.0</S100XC:version>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
@@ -572,7 +572,7 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>101</S100XC:number>
+                <S100XC:number>214</S100XC:number>
 		<S100XC:version>1.1.0</S100XC:version>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
@@ -609,7 +609,7 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>101</S100XC:number>
+                <S100XC:number>214</S100XC:number>
 		<S100XC:version>1.1.0</S100XC:version>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
@@ -646,7 +646,7 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>101</S100XC:number>
+                <S100XC:number>214</S100XC:number>
 		<S100XC:version>1.1.0</S100XC:version>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
@@ -683,7 +683,7 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>101</S100XC:number>
+                <S100XC:number>214</S100XC:number>
 		<S100XC:version>1.1.0</S100XC:version>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
@@ -720,7 +720,7 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>101</S100XC:number>
+                <S100XC:number>214</S100XC:number>
 		<S100XC:version>1.1.0</S100XC:version>
             </S100XC:productSpecification>
             <S100XC:producingAgency>

--- a/S-101_Test_DataSets/exports/2.0/IHO_V12/S100_ROOT/CATALOG.XML
+++ b/S-101_Test_DataSets/exports/2.0/IHO_V12/S100_ROOT/CATALOG.XML
@@ -54,7 +54,8 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>1</S100XC:number>
+                <S100XC:number>101</S100XC:number>
+		<S100XC:version>1.1.0</S100XC:version>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
                 <cit:CI_Responsibility>
@@ -90,7 +91,8 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>1</S100XC:number>
+                <S100XC:number>101</S100XC:number>
+                <S100XC:version>1.1.0</S100XC:version>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
                 <cit:CI_Responsibility>
@@ -126,7 +128,8 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>1</S100XC:number>
+                <S100XC:number>101</S100XC:number>
+		<S100XC:version>1.1.0</S100XC:version>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
                 <cit:CI_Responsibility>
@@ -162,7 +165,8 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>1</S100XC:number>
+                <S100XC:number>101</S100XC:number>
+		<S100XC:version>1.1.0</S100XC:version>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
                 <cit:CI_Responsibility>
@@ -198,7 +202,8 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>1</S100XC:number>
+                <S100XC:number>101</S100XC:number>
+		<S100XC:version>1.1.0</S100XC:version>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
                 <cit:CI_Responsibility>
@@ -234,7 +239,8 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>1</S100XC:number>
+                <S100XC:number>101</S100XC:number>
+		<S100XC:version>1.1.0</S100XC:version>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
                 <cit:CI_Responsibility>
@@ -270,7 +276,8 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>1</S100XC:number>
+                <S100XC:number>101</S100XC:number>
+		<S100XC:version>1.1.0</S100XC:version>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
                 <cit:CI_Responsibility>
@@ -306,7 +313,8 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>1</S100XC:number>
+                <S100XC:number>101</S100XC:number>
+		<S100XC:version>1.1.0</S100XC:version>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
                 <cit:CI_Responsibility>
@@ -342,7 +350,8 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>1</S100XC:number>
+                <S100XC:number>101</S100XC:number>
+		<S100XC:version>1.1.0</S100XC:version>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
                 <cit:CI_Responsibility>
@@ -378,7 +387,8 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>1</S100XC:number>
+                <S100XC:number>101</S100XC:number>
+		<S100XC:version>1.1.0</S100XC:version>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
                 <cit:CI_Responsibility>
@@ -414,7 +424,8 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>1</S100XC:number>
+                <S100XC:number>101</S100XC:number>
+		<S100XC:version>1.1.0</S100XC:version>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
                 <cit:CI_Responsibility>
@@ -450,7 +461,8 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>1</S100XC:number>
+                <S100XC:number>101</S100XC:number>
+		<S100XC:version>1.1.0</S100XC:version>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
                 <cit:CI_Responsibility>
@@ -486,7 +498,8 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>1</S100XC:number>
+                <S100XC:number>101</S100XC:number>
+		<S100XC:version>1.1.0</S100XC:version>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
                 <cit:CI_Responsibility>
@@ -522,7 +535,8 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>1</S100XC:number>
+                <S100XC:number>101</S100XC:number>
+		<S100XC:version>1.1.0</S100XC:version>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
                 <cit:CI_Responsibility>
@@ -558,7 +572,8 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>1</S100XC:number>
+                <S100XC:number>101</S100XC:number>
+		<S100XC:version>1.1.0</S100XC:version>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
                 <cit:CI_Responsibility>
@@ -594,7 +609,8 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>1</S100XC:number>
+                <S100XC:number>101</S100XC:number>
+		<S100XC:version>1.1.0</S100XC:version>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
                 <cit:CI_Responsibility>
@@ -630,7 +646,8 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>1</S100XC:number>
+                <S100XC:number>101</S100XC:number>
+		<S100XC:version>1.1.0</S100XC:version>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
                 <cit:CI_Responsibility>
@@ -666,7 +683,8 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>1</S100XC:number>
+                <S100XC:number>101</S100XC:number>
+		<S100XC:version>1.1.0</S100XC:version>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
                 <cit:CI_Responsibility>
@@ -702,7 +720,8 @@
             <S100XC:issueTime>10:14:32Z</S100XC:issueTime>
             <S100XC:productSpecification>
                 <S100XC:productIdentifier>S-101</S100XC:productIdentifier>
-                <S100XC:number>1</S100XC:number>
+                <S100XC:number>101</S100XC:number>
+		<S100XC:version>1.1.0</S100XC:version>
             </S100XC:productSpecification>
             <S100XC:producingAgency>
                 <cit:CI_Responsibility>


### PR DESCRIPTION
Due to this issue https://github.com/iho-ohi/S-101-Test-Datasets/issues/22, as well as the incorrect XML usage of {http://www.iho.int/s100/xc/5.0}:S100_PT_Locale_PropertyType, which doesn't exist from the schema definitions I've seen, I am unable to upload these exchange sets in /S-101_Test_DataSets/exports/.

Basically, in our system if an exchange catalog does not provide the S100_CatalogueDiscoveryMetadata for the exact feature and portrayal catalog, we have to go by the product specification nodes from either the root level of the exchange catalog, or the discovery metadata nodes in order to select the product version to install it as. As far as I'm aware in S-100 WG 9, it was discussed that any version specification in the exchange catalog should follow the format like I've provided per HSSC resolution.

Using the .NET xml serialization apis we have available to us, makes the system very particular to which types are allowed, and since S100_PT_Locale_PropertyType is a defined type in version 4.0 of S-100 and the schema for the catalog is listed as S-100 5.0, the defaultLocale of S100_DatasetDiscoveryMetadata should be {http://standards.iso.org/iso/19115/-3/lan/1.0}:PT_Locale_PropertyType, as defined in [5.0.0](https://github.com/kaspernielsen/S-100-xmlbindings/blob/main/specifications/s-100/5.0.0/S100Catalog/20220705/S100_ExchangeCatalogue.xsd)